### PR TITLE
兼容强制授权需要用户弹窗参数

### DIFF
--- a/app/controller/Index.php
+++ b/app/controller/Index.php
@@ -21,6 +21,8 @@ class Index extends BaseController
         $redirect_uri = input('get.redirect_uri');
         $scope = input('?get.scope') ? input('get.scope') : 'snsapi_base';
         $state = input('get.state');
+        $forcePopup	= input('?get.forcePopup') ? input('get.forcePopup') : 'false';
+        
         if (!$appid || !$redirect_uri || !$scope) return $this->error('参数不能为空');
         if (!filter_var($redirect_uri, FILTER_VALIDATE_URL)) return $this->error('redirect_uri参数错误');
 
@@ -48,6 +50,7 @@ class Index extends BaseController
             "redirect_uri" => $redirect_uri,
             "response_type" => "code",
             "scope" => $scope,
+            "forcePopup" => $forcePopup,
             "state" => $state
         ];
         if (input('?get.agentid')) $param['agentid'] = input('get.agentid');


### PR DESCRIPTION
## 文档：[https://developers.weixin.qq.com/doc/service/guide/h5/auth.html](https://developers.weixin.qq.com/doc/service/guide/h5/auth.html)
# 参数说明：`forcePopup`

**字段名**：`forcePopup`  
**类型**：`Boolean`  
**是否必填**：否  
**默认值**：`false`

---

## 🧩 参数描述

`forcePopup` 用于控制 **本次授权是否强制弹窗确认**。

- 当值为 `true` 时：  
  系统将 **强制触发用户授权弹窗**，即使用户曾经已授权过。
- 当值为 `false`（默认）：  
  若用户此前已授权并命中静默授权逻辑，则 **不会弹窗**，直接静默获取授权。

---

## ⚠️ 注意事项

- 若用户命中了 **特殊场景下的静默授权逻辑**，则此参数 **不会生效**。
- 即使设置为 `true`，在某些平台或授权状态下，也可能依旧不会弹窗。
- 建议仅在需要用户重新确认授权时使用（例如：权限升级、关键操作确认等场景）。

---